### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/ess-smart-underscore.el
+++ b/ess-smart-underscore.el
@@ -10,6 +10,7 @@
 ;;           By: Matthew L. Fidler
 ;;     Update #: 137
 ;; URL: http://github.com/mlf176f2/ess-smart-underscore.el
+;; Package-Requires: ((ess "0"))
 ;; Keywords: ESS, underscore
 ;; Compatibility:
 ;; 


### PR DESCRIPTION
When installing this package from Melpa (or any other ELPA repository in which it might be found) then `ess` should also be installed. This commit adds the corresponding `Package-Requires` header. Feel free to adjust the required version if desired.
